### PR TITLE
feat: introduce new variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ yarn.lock
 *.iml
 /public
 /vc-test-suite
+.DS_Store

--- a/src/2.0/__tests__/e2e.test.ts
+++ b/src/2.0/__tests__/e2e.test.ts
@@ -162,7 +162,7 @@ describe("2.0 E2E Test Scenarios", () => {
     test("should return true when document is valid and version is 2.0", () => {
       expect(
         validateSchema({
-          version: "https://schema.openattestation.com/2.0/schema.json",
+          version: "https://schema.tradetrust.io/2.0/schema.json",
           data: {
             issuers: [
               {

--- a/src/2.0/schema/schema.json
+++ b/src/2.0/schema/schema.json
@@ -1,6 +1,6 @@
 {
-  "title": "Open Attestation Schema 2.0",
-  "$id": "https://schema.openattestation.com/2.0/schema.json",
+  "title": "TradeTrust Schema 2.0",
+  "$id": "https://schema.tradetrust.io/2.0/schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "identityProofDns": {

--- a/src/3.0/schema/schema.json
+++ b/src/3.0/schema/schema.json
@@ -1,6 +1,6 @@
 {
-  "title": "Open Attestation Schema 3.0",
-  "$id": "https://schema.openattestation.com/3.0/schema.json",
+  "title": "TradeTrust Schema 3.0",
+  "$id": "https://schema.tradetrust.io/3.0/schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "definitions": {
@@ -190,7 +190,7 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["DNS-TXT", "DNS-DID", "DID"]
+              "enum": ["DNS-TXT", "DNS-DID", "DID", "IDVC"]
             },
             "identifier": {
               "type": "string",

--- a/src/3.0/schema/schema.test.ts
+++ b/src/3.0/schema/schema.test.ts
@@ -668,7 +668,7 @@ describe("schema/3.0", () => {
               keyword: "enum",
               instancePath: "/openAttestationMetadata/identityProof/type",
               schemaPath: "#/properties/openAttestationMetadata/properties/identityProof/properties/type/enum",
-              params: { allowedValues: ["DNS-TXT", "DNS-DID", "DID"] },
+              params: { allowedValues: ["DNS-TXT", "DNS-DID", "DID", "IDVC"] },
               message: "must be equal to one of the allowed values",
             },
           ])

--- a/src/shared/@types/document.ts
+++ b/src/shared/@types/document.ts
@@ -25,8 +25,8 @@ export type SignedWrappedDocument<T extends OpenAttestationDocument> = T extends
   : unknown;
 
 export enum SchemaId {
-  v2 = "https://schema.openattestation.com/2.0/schema.json",
-  v3 = "https://schema.openattestation.com/3.0/schema.json",
+  v2 = "https://schema.tradetrust.io/2.0/schema.json",
+  v3 = "https://schema.tradetrust.io/3.0/schema.json",
 }
 
 export const OpenAttestationHexString = String.withConstraint(

--- a/src/shared/utils/__tests__/utils.test.ts
+++ b/src/shared/utils/__tests__/utils.test.ts
@@ -439,7 +439,7 @@ describe("Util Functions", () => {
           "type": [
             "VerifiableCredential",
           ],
-          "version": "https://schema.openattestation.com/3.0/schema.json",
+          "version": "https://schema.tradetrust.io/3.0/schema.json",
         }
       `);
     });

--- a/test/fixtures/v3/did-wrapped.json
+++ b/test/fixtures/v3/did-wrapped.json
@@ -1,5 +1,5 @@
 {
-  "version": "https://schema.openattestation.com/3.0/schema.json",
+  "version": "https://schema.tradetrust.io/3.0/schema.json",
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
     "https://schemata.openattestation.com/com/openattestation/1.0/DrivingLicenceCredential.json",

--- a/test/fixtures/v3/not-obfuscated-wrapped.json
+++ b/test/fixtures/v3/not-obfuscated-wrapped.json
@@ -1,5 +1,5 @@
 {
-  "version": "https://schema.openattestation.com/3.0/schema.json",
+  "version": "https://schema.tradetrust.io/3.0/schema.json",
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
     "https://schemata.openattestation.com/com/openattestation/1.0/DrivingLicenceCredential.json",

--- a/test/fixtures/v3/obfuscated-wrapped.json
+++ b/test/fixtures/v3/obfuscated-wrapped.json
@@ -1,5 +1,5 @@
 {
-  "version": "https://schema.openattestation.com/3.0/schema.json",
+  "version": "https://schema.tradetrust.io/3.0/schema.json",
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
     "https://schemata.openattestation.com/com/openattestation/1.0/DrivingLicenceCredential.json",

--- a/test/fixtures/v3/wrapped-transferable-document.json
+++ b/test/fixtures/v3/wrapped-transferable-document.json
@@ -1,5 +1,5 @@
 {
-  "version": "https://schema.openattestation.com/3.0/schema.json",
+  "version": "https://schema.tradetrust.io/3.0/schema.json",
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
     "https://schemata.openattestation.com/com/openattestation/1.0/DrivingLicenceCredential.json",


### PR DESCRIPTION
## Summary

What is the background of this pull request?
- This is the one of the many forked repos from open-attestation in order for the ndi-tradex-poc to happen.
- https://www.pivotaltracker.com/story/show/186245911

## What are the changes?
- This modifies the underlying base schema for version 3.0 of open-attestation schema.
- It also renames the wrong links pointing to the upstream's schemas to the customised ones found at https://schema.tradetrust.io/3.0/schema.json.
- Even though there isnt a need to modify the 2.0 upstream's schemas links, i've done so for organisation sake. 

## Issues

What are the related issues or stories?
- renaming of all open-attestation names could be taken at a later date.
