### PR TITLE
fix: export interface diagnose error

### DIFF
--- a/src/shared/utils/diagnose.ts
+++ b/src/shared/utils/diagnose.ts
@@ -13,7 +13,7 @@ import { Kind, Mode } from "./@types/diagnose";
 
 type Version = "2.0" | "3.0";
 
-interface DiagnoseError {
+export interface DiagnoseError {
   message: string;
 }
 


### PR DESCRIPTION
## Summary

As tradetrust core is importing the `diagnose` method, it can not be imported as the response type from `diagnose` method, `DiagnoseError` is not exported from this `tradetrust/tradetrust` package.

## Changes

export interface `DiagnoseError` from `src/shared/utils/diagnose.ts`
