### PR TITLE
fix: bump w3c vc version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@govtechsg/jsonld": "^0.1.1",
-        "@trustvc/w3c-vc": "^1.2.17",
+        "@trustvc/w3c-vc": "^1.3.0-alpha.5",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
         "cross-fetch": "^4.0.0",
@@ -971,6 +971,189 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@digitalbazaar/bbs-signatures": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/bbs-signatures/-/bbs-signatures-3.0.0.tgz",
+      "integrity": "sha512-mQMCMnCWAraVSswJg1kJK/qmUrb3jMoWB9c8kOmztsWfnMZJcyYAcavuF8jgrVZ5cl/ZRNMK61ZbIvkqd6BE6g==",
+      "dependencies": {
+        "@noble/curves": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@digitalbazaar/bls12-381-multikey": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/bls12-381-multikey/-/bls12-381-multikey-2.1.0.tgz",
+      "integrity": "sha512-JelU85fNhvHl2/mqRdmrtrE2ZQJ0//+UwI0l/YFmvsOr6YN2GuKPzdkfXjpm7f3UvnBqz5f8QKFTb9mVa7mVVg==",
+      "dependencies": {
+        "@digitalbazaar/bbs-signatures": "^3.0.0",
+        "@noble/curves": "^1.3.0",
+        "base58-universal": "^2.0.0",
+        "base64url-universal": "^2.0.0",
+        "cborg": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@digitalbazaar/data-integrity": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/data-integrity/-/data-integrity-2.5.0.tgz",
+      "integrity": "sha512-ohIieLfgtPQU9BYfj0eKNiz55/ZDOk5YSE9FN/Hn0eXzI8WQzLkzRvC8pvBnzuzXDgCsjPdSqYvzok5PoClMBQ==",
+      "dependencies": {
+        "base58-universal": "^2.0.0",
+        "base64url-universal": "^2.0.0",
+        "jsonld-signatures": "^11.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@digitalbazaar/data-integrity/node_modules/jsonld": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-8.3.3.tgz",
+      "integrity": "sha512-9YcilrF+dLfg9NTEof/mJLMtbdX1RJ8dbWtJgE00cMOIohb1lIyJl710vFiTaiHTl6ZYODJuBd32xFvUhmv3kg==",
+      "dependencies": {
+        "@digitalbazaar/http-client": "^3.4.1",
+        "canonicalize": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "rdf-canonize": "^3.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@digitalbazaar/data-integrity/node_modules/jsonld-signatures": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-11.5.0.tgz",
+      "integrity": "sha512-Kdto+e8uvY/5u3HYkmAbpy52bplWX9uqS8fmqdCv6oxnCFwCTM0hMt6r4rWqlhw5/aHoCHJIRxwYb4QKGC69Jw==",
+      "dependencies": {
+        "@digitalbazaar/security-context": "^1.0.0",
+        "jsonld": "^8.0.0",
+        "rdf-canonize": "^4.0.1",
+        "serialize-error": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@digitalbazaar/data-integrity/node_modules/jsonld-signatures/node_modules/rdf-canonize": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-4.0.1.tgz",
+      "integrity": "sha512-B5ynHt4sasbUafzrvYI2GFARgeFcD8Sx9yXPbg7gEyT2EH76rlCv84kyO6tnxzVbxUN/uJDbK1S/MXh+DsnuTA==",
+      "dependencies": {
+        "setimmediate": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@digitalbazaar/data-integrity/node_modules/serialize-error": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+      "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@digitalbazaar/di-sd-primitives": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/di-sd-primitives/-/di-sd-primitives-3.1.0.tgz",
+      "integrity": "sha512-qi8H5yz4R6UmNWC6t99MSxFexniWZHME39Q77ev03afkgLMRMQSVwNGybrgeIK1VOKn0uF4YQj8quhkNlg5baQ==",
+      "dependencies": {
+        "base64url-universal": "^2.0.0",
+        "jsonld": "^8.3.2",
+        "klona": "^2.0.6",
+        "rdf-canonize": "^4.0.1",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@digitalbazaar/di-sd-primitives/node_modules/jsonld": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-8.3.3.tgz",
+      "integrity": "sha512-9YcilrF+dLfg9NTEof/mJLMtbdX1RJ8dbWtJgE00cMOIohb1lIyJl710vFiTaiHTl6ZYODJuBd32xFvUhmv3kg==",
+      "dependencies": {
+        "@digitalbazaar/http-client": "^3.4.1",
+        "canonicalize": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "rdf-canonize": "^3.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@digitalbazaar/di-sd-primitives/node_modules/jsonld/node_modules/rdf-canonize": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.4.0.tgz",
+      "integrity": "sha512-fUeWjrkOO0t1rg7B2fdyDTvngj+9RlUyL92vOdiB7c0FPguWVsniIMjEtHH+meLBO9rzkUlUzBVXgWrjI8P9LA==",
+      "dependencies": {
+        "setimmediate": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@digitalbazaar/di-sd-primitives/node_modules/rdf-canonize": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-4.0.1.tgz",
+      "integrity": "sha512-B5ynHt4sasbUafzrvYI2GFARgeFcD8Sx9yXPbg7gEyT2EH76rlCv84kyO6tnxzVbxUN/uJDbK1S/MXh+DsnuTA==",
+      "dependencies": {
+        "setimmediate": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@digitalbazaar/di-sd-primitives/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@digitalbazaar/ecdsa-multikey": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/ecdsa-multikey/-/ecdsa-multikey-1.8.0.tgz",
+      "integrity": "sha512-Xo4oBCb0bJv6PYNBrLBZfR/jA2uNd9Bi+YTnadFtxTbhMQrSN0nTw3OnTBOOC7zxtL3t4N00ZweQM4zhsV6gVQ==",
+      "dependencies": {
+        "base58-universal": "^2.0.0",
+        "base64url-universal": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@digitalbazaar/ecdsa-sd-2023-cryptosuite": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/ecdsa-sd-2023-cryptosuite/-/ecdsa-sd-2023-cryptosuite-3.4.1.tgz",
+      "integrity": "sha512-PzKQneakxUUS/kzDgUZ0ZcZKuHhMhAelW2Bp/rryHEV43VeI3meoJkuQ0s7sfMlD1OWkKWrNClMr1znwBaQiLQ==",
+      "dependencies": {
+        "@digitalbazaar/di-sd-primitives": "^3.0.4",
+        "@digitalbazaar/ecdsa-multikey": "^1.1.3",
+        "base58-universal": "^2.0.0",
+        "base64url-universal": "^2.0.0",
+        "cborg": "^4.0.5",
+        "klona": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@digitalbazaar/http-client": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-3.4.1.tgz",
@@ -983,6 +1166,11 @@
       "engines": {
         "node": ">=14.0"
       }
+    },
+    "node_modules/@digitalbazaar/security-context": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/security-context/-/security-context-1.0.1.tgz",
+      "integrity": "sha512-0WZa6tPiTZZF8leBtQgYAfXQePFQp2z5ivpCEN/iZguYYZ0TB9qRmWtan5XH6mNFuusHtMcyIzAcReyE6rZPhA=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -2519,6 +2707,20 @@
         "yarn": "1.x"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
@@ -3886,24 +4088,77 @@
       "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
     },
     "node_modules/@trustvc/w3c-context": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/@trustvc/w3c-context/-/w3c-context-1.2.13.tgz",
-      "integrity": "sha512-Qii0ExOuTZhBirmzPhdX0o0R1P8DOc8UYEmU+XQ5ouOmQNOqyMkikS0IvFXTb7LmUD3I2d8pT6BMKyY2S8Ac/A==",
+      "version": "1.3.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@trustvc/w3c-context/-/w3c-context-1.3.0-alpha.5.tgz",
+      "integrity": "sha512-ZB6rPH2XfMtjO2sMuSWpkY47XC1rjk8p5tFHmQrdP9y7eegko4x2o2Mw9z+bjmjVpKQBwQV93lrwEpKbgeih7g==",
       "dependencies": {
         "did-resolver": "^4.1.0",
-        "jsonld-signatures": "^7.0.0"
+        "jsonld-signatures": "^11.5.0"
       },
       "engines": {
         "node": ">=18.x"
       }
     },
-    "node_modules/@trustvc/w3c-credential-status": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/@trustvc/w3c-credential-status/-/w3c-credential-status-1.2.13.tgz",
-      "integrity": "sha512-GNT+r00pscDdjSnTEbH3XQgidKKPblurZnWtCu8OydDilXkMH4p7Lc7JrvvCoIn6W2Iwv0em6107gB7rsW3yXA==",
+    "node_modules/@trustvc/w3c-context/node_modules/jsonld": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-8.3.3.tgz",
+      "integrity": "sha512-9YcilrF+dLfg9NTEof/mJLMtbdX1RJ8dbWtJgE00cMOIohb1lIyJl710vFiTaiHTl6ZYODJuBd32xFvUhmv3kg==",
       "dependencies": {
-        "@trustvc/w3c-context": "^1.2.13",
-        "@trustvc/w3c-issuer": "^1.2.4",
+        "@digitalbazaar/http-client": "^3.4.1",
+        "canonicalize": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "rdf-canonize": "^3.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@trustvc/w3c-context/node_modules/jsonld-signatures": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-11.5.0.tgz",
+      "integrity": "sha512-Kdto+e8uvY/5u3HYkmAbpy52bplWX9uqS8fmqdCv6oxnCFwCTM0hMt6r4rWqlhw5/aHoCHJIRxwYb4QKGC69Jw==",
+      "dependencies": {
+        "@digitalbazaar/security-context": "^1.0.0",
+        "jsonld": "^8.0.0",
+        "rdf-canonize": "^4.0.1",
+        "serialize-error": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@trustvc/w3c-context/node_modules/jsonld-signatures/node_modules/rdf-canonize": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-4.0.1.tgz",
+      "integrity": "sha512-B5ynHt4sasbUafzrvYI2GFARgeFcD8Sx9yXPbg7gEyT2EH76rlCv84kyO6tnxzVbxUN/uJDbK1S/MXh+DsnuTA==",
+      "dependencies": {
+        "setimmediate": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@trustvc/w3c-context/node_modules/serialize-error": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+      "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@trustvc/w3c-credential-status": {
+      "version": "1.3.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@trustvc/w3c-credential-status/-/w3c-credential-status-1.3.0-alpha.5.tgz",
+      "integrity": "sha512-DDutnna2nfB2ewDYLdU8ZmnDE6SpnbdXTKUco0JmRTsvTs3zuVQp8uG5ng0tAhdf4hYtmyX4IEQijpaEMZXB1g==",
+      "dependencies": {
+        "@trustvc/w3c-context": "^1.3.0-alpha.5",
+        "@trustvc/w3c-issuer": "^1.3.0-alpha.3",
         "base64url-universal": "^2.0.0",
         "pako": "^2.1.0"
       },
@@ -3917,10 +4172,12 @@
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "node_modules/@trustvc/w3c-issuer": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@trustvc/w3c-issuer/-/w3c-issuer-1.2.4.tgz",
-      "integrity": "sha512-BRxdb+VxKVj3N/ukivpPF0oP1dvlMOSZjoOLF+F4jMsJVcs2+8QIJbvCQJNiB6I+ji6On4uvvRPOmc8tYhOt+w==",
+      "version": "1.3.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@trustvc/w3c-issuer/-/w3c-issuer-1.3.0-alpha.3.tgz",
+      "integrity": "sha512-63dcF9BpSUaYZ1GhNCmcomc/Qin244Kkdgfh1Dv6zJ1a9R4A6LCK14LMBPVe2iNuJ+kKNNrkVRtyCW6d04fSeg==",
       "dependencies": {
+        "@digitalbazaar/bls12-381-multikey": "^2.1.0",
+        "@digitalbazaar/ecdsa-multikey": "^1.8.0",
         "@mattrglobal/bls12381-key-pair": "^1.2.1",
         "bip39": "^3.1.0",
         "did-resolver": "^4.1.0",
@@ -3974,16 +4231,20 @@
       }
     },
     "node_modules/@trustvc/w3c-vc": {
-      "version": "1.2.17",
-      "resolved": "https://registry.npmjs.org/@trustvc/w3c-vc/-/w3c-vc-1.2.17.tgz",
-      "integrity": "sha512-R7dz16D5mmb7tsPt71o/XAqaKaNA0J0du0ZOa16i7x3I9yPCx11jwCYdb0NYzsCXrWa318mqS2u7MCtzvEVBBQ==",
+      "version": "1.3.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@trustvc/w3c-vc/-/w3c-vc-1.3.0-alpha.5.tgz",
+      "integrity": "sha512-Y7fpxUzzTqq7zCBMPAAYfKARLzt4aKSHb6yYELdNsWBetTjfOOmFbSSsjIGfj2/8vTkyzpgqJezkK+H6FDrMYg==",
       "dependencies": {
+        "@digitalbazaar/data-integrity": "^2.5.0",
+        "@digitalbazaar/ecdsa-multikey": "^1.8.0",
+        "@digitalbazaar/ecdsa-sd-2023-cryptosuite": "^3.4.1",
         "@mattrglobal/jsonld-signatures-bbs": "^1.2.0",
-        "@trustvc/w3c-credential-status": "^1.2.13",
-        "@trustvc/w3c-issuer": "^1.2.4",
+        "@trustvc/w3c-credential-status": "^1.3.0-alpha.5",
+        "@trustvc/w3c-issuer": "^1.3.0-alpha.3",
         "did-resolver": "^4.1.0",
         "jsonld": "^6.0.0",
-        "jsonld-signatures": "7.0.0",
+        "jsonld-signatures": "^11.5.0",
+        "jsonld-signatures-v7": "npm:jsonld-signatures@7.0.0",
         "uuid": "^10.0.0"
       },
       "engines": {
@@ -3991,6 +4252,70 @@
       },
       "peerDependencies": {
         "jsonld": "^6.0.0"
+      }
+    },
+    "node_modules/@trustvc/w3c-vc/node_modules/jsonld-signatures": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-11.5.0.tgz",
+      "integrity": "sha512-Kdto+e8uvY/5u3HYkmAbpy52bplWX9uqS8fmqdCv6oxnCFwCTM0hMt6r4rWqlhw5/aHoCHJIRxwYb4QKGC69Jw==",
+      "dependencies": {
+        "@digitalbazaar/security-context": "^1.0.0",
+        "jsonld": "^8.0.0",
+        "rdf-canonize": "^4.0.1",
+        "serialize-error": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@trustvc/w3c-vc/node_modules/jsonld-signatures/node_modules/jsonld": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-8.3.3.tgz",
+      "integrity": "sha512-9YcilrF+dLfg9NTEof/mJLMtbdX1RJ8dbWtJgE00cMOIohb1lIyJl710vFiTaiHTl6ZYODJuBd32xFvUhmv3kg==",
+      "dependencies": {
+        "@digitalbazaar/http-client": "^3.4.1",
+        "canonicalize": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "rdf-canonize": "^3.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@trustvc/w3c-vc/node_modules/jsonld-signatures/node_modules/jsonld/node_modules/rdf-canonize": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.4.0.tgz",
+      "integrity": "sha512-fUeWjrkOO0t1rg7B2fdyDTvngj+9RlUyL92vOdiB7c0FPguWVsniIMjEtHH+meLBO9rzkUlUzBVXgWrjI8P9LA==",
+      "dependencies": {
+        "setimmediate": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@trustvc/w3c-vc/node_modules/jsonld-signatures/node_modules/rdf-canonize": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-4.0.1.tgz",
+      "integrity": "sha512-B5ynHt4sasbUafzrvYI2GFARgeFcD8Sx9yXPbg7gEyT2EH76rlCv84kyO6tnxzVbxUN/uJDbK1S/MXh+DsnuTA==",
+      "dependencies": {
+        "setimmediate": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@trustvc/w3c-vc/node_modules/serialize-error": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+      "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@trustvc/w3c-vc/node_modules/uuid": {
@@ -5011,6 +5336,14 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/base58-universal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base58-universal/-/base58-universal-2.0.0.tgz",
+      "integrity": "sha512-BgkgF8zVLOAygszG4W8NkLm7iXrw80VYAOcedrzANrIhS14+4W6zVqjyGTFUBM/FpqkHUt8aAYd4DbBBfn3zKg==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -5381,6 +5714,14 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/cborg": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.13.tgz",
+      "integrity": "sha512-HAiZCITe/5Av0ukt6rOYE+VjnuFGfujN3NUKgEbIlONpRpsYMZAa+Bjk16mj6dQMuB0n81AuNrcB9YVMshcrfA==",
+      "bin": {
+        "cborg": "lib/bin.js"
       }
     },
     "node_modules/chalk": {
@@ -10519,6 +10860,72 @@
         "node": ">=10"
       }
     },
+    "node_modules/jsonld-signatures-v7": {
+      "name": "jsonld-signatures",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-7.0.0.tgz",
+      "integrity": "sha512-J/nA+llcYYjErPHG9WFpXvR82TOg5fbHk/7rXbx4Ts854DPReaKAAd0hAZ+s5/P2WIIAZPIHCqA+iz1QrOqeiQ==",
+      "dependencies": {
+        "base64url": "^3.0.1",
+        "crypto-ld": "^3.7.0",
+        "jsonld": "^4.0.1",
+        "node-forge": "^0.10.0",
+        "security-context": "^4.0.0",
+        "serialize-error": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jsonld-signatures-v7/node_modules/jsonld": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-4.0.1.tgz",
+      "integrity": "sha512-ltEqMQB37ZxZnsgmI+9rqHYkz1M6PqUykuS1t2aQNuH1oiLrUDYz5nyVkHQDgjFd7CFKTIWeLiNhwdwFrH5o5A==",
+      "dependencies": {
+        "canonicalize": "^1.0.1",
+        "lru-cache": "^5.1.1",
+        "object.fromentries": "^2.0.2",
+        "rdf-canonize": "^2.0.1",
+        "request": "^2.88.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonld-signatures-v7/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/jsonld-signatures-v7/node_modules/rdf-canonize": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-2.0.1.tgz",
+      "integrity": "sha512-/GVELjrfW8G/wS4QfDZ5Kq68cS1belVNJqZlcwiErerexeBUsgOINCROnP7UumWIBNdeCwTVLE9NVXMnRYK0lA==",
+      "dependencies": {
+        "semver": "^6.3.0",
+        "setimmediate": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonld-signatures-v7/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/jsonld-signatures-v7/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+    },
     "node_modules/jsonld-signatures/node_modules/jsonld": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-4.0.1.tgz",
@@ -10632,6 +11039,14 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/klona": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/ky": {
@@ -18353,7 +18768,6 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@govtechsg/jsonld": "^0.1.1",
-    "@trustvc/w3c-vc": "^1.2.17",
+    "@trustvc/w3c-vc": "^1.3.0-alpha.5",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "cross-fetch": "^4.0.0",


### PR DESCRIPTION
## Summary
bump w3c vc version



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Upgraded a core verifiable credentials library to the latest pre-release version, incorporating upstream fixes and enhancements.
  - Improves compatibility with recent ecosystem updates and may enhance stability and interoperability.
  - No direct user-facing changes are expected; existing functionality should continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->